### PR TITLE
Fix GET docblock for an array of Symfony items

### DIFF
--- a/src/Generator/GetGenerator.php
+++ b/src/Generator/GetGenerator.php
@@ -40,6 +40,7 @@ class GetGenerator
             $initString = str_replace(',App', ',\\App', $initString);
             $initString = str_replace(',Tbn', ',\\Tbn', $initString);
             $initString = str_replace('Doctrine', '\\Doctrine', $initString);
+            $initString = str_replace('Symfony', '\\Symfony', $initString);
 
             $dockblock = "@return $initString";
         }


### PR DESCRIPTION
docblock was generating phpstan error if property is an array of Symfony object
e.g. UploadedFile namespace is \Symfony\Component\HttpFoundation\File\UploadedFile

before :
```
/**
 * @return array<int,Symfony\Component\HttpFoundation\File\UploadedFile>
 */
```

after : 
```
/**
 * @return array<int,\Symfony\Component\HttpFoundation\File\UploadedFile>
 */
```